### PR TITLE
define process.type in renderer process

### DIFF
--- a/positron/components/Process.js
+++ b/positron/components/Process.js
@@ -85,6 +85,10 @@ Process.prototype = {
     return this._processGlobal.release;
   },
 
+  get type() {
+    return this._processGlobal.type;
+  },
+
   get versions() {
     return this._processGlobal.versions;
   },

--- a/positron/webidl/Process.webidl
+++ b/positron/webidl/Process.webidl
@@ -38,6 +38,7 @@ interface processImpl : EventEmitter {
   [Cached, Pure] readonly attribute unsigned long pid;
   [Cached, Pure] readonly attribute DOMString platform;
   [Cached, Pure] readonly attribute ReleaseDictionary release;
+  [Cached, Pure] readonly attribute DOMString type;
   [Cached, Pure] readonly attribute VersionDictionary versions;
   [Throws] any atomBinding(DOMString name);
   [Throws] any binding(DOMString name);


### PR DESCRIPTION
@brendandahl The "hello world" app is failing because of an error that appears to be the result of _process.type_ not being defined in the renderer process.  I'm not sure why that failure isn't happening with the current version of Electron, but presumably it doesn't reference that property in the renderer process.

In any case, here's the simple fix.
