### PR TITLE
subconfigure spidernode

### DIFF
--- a/positron/configure.in
+++ b/positron/configure.in
@@ -1,0 +1,11 @@
+debug_arg=""
+if test "$MOZ_DEBUG"; then
+    debug_arg="--debug"
+fi
+
+(
+  cd ${_topsrcdir}/positron/spidernode &&
+  which python2.7 > /dev/null &&
+  exec python2.7 ./configure --engine=spidermonkey --shared ${debug_arg} ||
+  exec python    ./configure --engine=spidermonkey --shared ${debug_arg}
+)

--- a/positron/configure.in
+++ b/positron/configure.in
@@ -3,6 +3,9 @@ if test "$MOZ_DEBUG"; then
     debug_arg="--debug"
 fi
 
+CXXFLAGS="-mmacosx-version-min=10.9"
+LDFLAGS="-mmacosx-version-min=10.9"
+
 (
   cd ${_topsrcdir}/positron/spidernode &&
   which python2.7 > /dev/null &&


### PR DESCRIPTION
I'm not sure that this is the "right" way to do it, but this change enables subconfiguration of the _positron/spidernode/_ subdirectory during Positron configuration (i.e. `./mach configure`).

(There are subdirectories whose subconfiguration is driven by AC_OUTPUT_SUBDIRS, but that macro evaluates the configure script as a shell script, whereas in the case of SpiderNode it's a Python script.)
