### PR TITLE
implement clean and distclean targets for SpiderNode dependency

### DIFF
--- a/positron/webidl/Makefile.in
+++ b/positron/webidl/Makefile.in
@@ -50,3 +50,11 @@ spidernode:
 	$(MAKE) -C $(topsrcdir)/positron/spidernode/out BUILDTYPE=$(BUILDTYPE)
 	mkdir -p $(topobjdir)/positron/app/spidernode/.libs
 	cp $(SPIDERNODE_LIB_PATHS) $(topobjdir)/positron/app/spidernode/.libs/
+
+clean::
+	cd $(topobjdir)/positron/app/spidernode/.libs/ && rm -f $(SPIDERNODE_LIBS)
+	$(MAKE) -C $(topsrcdir)/positron/spidernode BUILDTYPE=$(BUILDTYPE) clean
+
+distclean::
+	cd $(topobjdir)/positron/app/spidernode/.libs/ && rm -f $(SPIDERNODE_LIBS)
+	$(MAKE) -C $(topsrcdir)/positron/spidernode BUILDTYPE=$(BUILDTYPE) distclean


### PR DESCRIPTION
@brendandahl This adds _clean_ and _distclean_ targets to the Positron Makefile for SpiderNode.

It would be even more useful to hook into `./mach clobber`, but I don't see an easy way to do that. In any case, `./mach clobber && ./mach build` does re-trigger the _spidernode_ target, since the clobber blows away the files in the objdir that the target depends upon. So it does trigger recompilation of SpiderNode, if needed.

And the long-term fix is probably to modify SpiderNode's tools/gyp_node.py to enable Positron's configure script to specify the SpiderNode _out_ dir, at which point we can point it to a subdirectory of the Positron objdir, and then `./mach clobber` will "just work."
