### PR TITLE
fail on reconfigure needed clearlyer

### DIFF
--- a/positron/webidl/Makefile.in
+++ b/positron/webidl/Makefile.in
@@ -44,9 +44,11 @@ SPIDERNODE_LIB_PATHS = $(foreach file,$(SPIDERNODE_LIBS),$(topsrcdir)/positron/s
 # TODO: figure out a way to configure spidernode to build to the positron output directory
 # 			(or configure positron to look for the libraries in the spidernode output directory)
 
-$(SPIDERNODE_TARGETS): spidernode
-
 spidernode:
-	$(MAKE) -C $(topsrcdir)/positron/spidernode/out BUILDTYPE=$(BUILDTYPE)
+	$(MAKE) -C $(topsrcdir)/positron/spidernode BUILDTYPE=$(BUILDTYPE)
+
+$(SPIDERNODE_LIB_PATHS): spidernode
+
+$(SPIDERNODE_TARGETS): $(SPIDERNODE_LIB_PATHS)
 	mkdir -p $(topobjdir)/positron/app/spidernode/.libs
 	cp $(SPIDERNODE_LIB_PATHS) $(topobjdir)/positron/app/spidernode/.libs/


### PR DESCRIPTION
@brendandahl Currently, if you distclean positron/spidernode/, then it needs to be reconfigured, but `mach build` doesn't realize that, and it fails on something like `make: *** /Users/myk/Projects/positron/positron/spidernode/out: No such file or directory.  Stop.`

This branch doesn't enable `mach build` to auto-reconfigure SpiderNode, the way it auto-reconfigures other parts of the codebase; but it does make the build fail with a better error message:

> 0:12.08 Makefile:77: **\* Stale config.gypi, please re-run ./configure.  Stop.
> 0:12.08 make[5]: **\* [spidernode] Error 2
> 0:12.08 make[4]: **\* [positron/webidl/target] Error 2

It also makes the SpiderNode libraries in the Positron objdir depend on their equivalents in the SpiderNode _out_ dir, so the former get recopied if the latter disappear or get touched.
