### PR TITLE
preserve CXXFLAGS and LDFLAGS when subconfiguring SpiderNode

### DIFF
--- a/positron/configure.in
+++ b/positron/configure.in
@@ -7,10 +7,18 @@ if test "$MOZ_DEBUG"; then
     debug_arg="--debug"
 fi
 
+case "$target" in
+*-darwin*)
+  CXXFLAGS="${CXXFLAGS} -mmacosx-version-min=10.9"
+  LDFLAGS="${LDFLAGS} -mmacosx-version-min=10.9"
+  ;;
+esac
+
+export CXXFLAGS
+export LDFLAGS
+
 (
   cd ${_topsrcdir}/positron/spidernode &&
-  export CXXFLAGS="-mmacosx-version-min=10.9" &&
-  export LDFLAGS="-mmacosx-version-min=10.9" &&
   which python2.7 > /dev/null &&
   exec python2.7 ./configure --engine=spidermonkey --enable-static ${debug_arg} --spidermonkey-obj-dir=${_objdir} ||
   exec python    ./configure --engine=spidermonkey --enable-static ${debug_arg} --spidermonkey-obj-dir=${_objdir}


### PR DESCRIPTION
I suspect that this will correct build errors on Linux caused by lack of the -fPIC flag, but I'm still building there, so I'm not yet sure it fixes that problem. It also isolates the Mac-specific flags to Darwin targets.
