### PR TITLE
fix linking on Linux

### DIFF
--- a/positron/webidl/moz.build
+++ b/positron/webidl/moz.build
@@ -24,6 +24,13 @@ USE_LIBS += [
     'static:/positron/app/spidernode/.libs/zlib',
 ]
 
+# Depend on mozglue.  This isn't needed on Mac, but it does seem to be needed
+# on Linux.  browser/app/moz.build does this unconditionally.  I wonder if we
+# should move it to positron/app/moz.build.
+USE_LIBS += [
+    'mozglue',
+]
+
 XPIDL_SOURCES += [
   'nsINodeLoader.idl',
 ]

--- a/toolkit/library/moz.build
+++ b/toolkit/library/moz.build
@@ -138,6 +138,20 @@ if 'gtk' in CONFIG['MOZ_WIDGET_TOOLKIT'] or \
         'freetype',
     ]
 
+# Force libxul to depend on the SpiderNode libs.  This shouldn't be here,
+# but I haven't been able to figure out how to get it to happen on Linux
+# without this hack.  Ugh.
+# TODO: figure out the right way do this.
+USE_LIBS += [
+    'static:/positron/app/spidernode/.libs/cares',
+    'static:/positron/app/spidernode/.libs/http_parser',
+    'static:/positron/app/spidernode/.libs/node',
+    'static:/positron/app/spidernode/.libs/openssl',
+    'static:/positron/app/spidernode/.libs/spidershim',
+    'static:/positron/app/spidernode/.libs/uv',
+    'static:/positron/app/spidernode/.libs/zlib',
+]
+
 if CONFIG['MOZ_WIDGET_TOOLKIT'] == 'cocoa':
     CXXFLAGS += CONFIG['TK_CFLAGS']
 


### PR DESCRIPTION
@brendandahl 

This fixes the Linux linking issues, provided you first merge https://github.com/mozilla/positron-spidernode/pull/1 in the SpiderNode submodule.

Of the two changes here, the mozglue fix is likely to be correct (although it might make more sense in a different moz.build file). The other one is almost certainly wrong, although hopefully it'll be sufficient until we find a better way (perhaps by using mozbuild's GYP support to generate moz.build files for SpiderNode).
